### PR TITLE
Just treat name as another 'perk'

### DIFF
--- a/DestinyArmourSelector/ArmourPieceCreator.cs
+++ b/DestinyArmourSelector/ArmourPieceCreator.cs
@@ -9,8 +9,8 @@ namespace DestinyArmourSelector
 
     class ArmourPieceCreator
     {
-        private ArmourType _armourType = ArmourType.Unknown;
-        private string _fileName = string.Empty;
+        private readonly ArmourType _armourType = ArmourType.Unknown;
+        private readonly string _fileName = string.Empty;
 
         public ArmourPieceCreator(string fileName, ArmourType type)
         {

--- a/DestinyArmourSelector/ArmourPieceFactory.cs
+++ b/DestinyArmourSelector/ArmourPieceFactory.cs
@@ -7,7 +7,7 @@ namespace DestinyArmourSelector
 
     public class ArmourPieceFactory
     {
-        private ArmourType _armourType = ArmourType.Unknown;
+        private readonly ArmourType _armourType = ArmourType.Unknown;
 
         public static ArmourPieceFactory Create(ArmourType armourType)
         {

--- a/DestinyArmourSelector/CsvReader.cs
+++ b/DestinyArmourSelector/CsvReader.cs
@@ -8,7 +8,7 @@ namespace DestinyArmourSelector
 
     class CsvReader
     {
-        private static string[] _empty = new string[] { };
+        private static readonly string[] _empty = new string[] { };
         private TextReader _reader;
 
         public CsvReader(TextReader reader)

--- a/DestinyArmourSelector/Program.cs
+++ b/DestinyArmourSelector/Program.cs
@@ -54,13 +54,16 @@ namespace DestinyArmourSelector
             ArmourPieceFactory factory = ArmourPieceFactory.Create(_armourType);
             IList<ArmourPiece> armourPieces = await creator.CreateArmourPieces();
 
-            var selector = new ArmourPieceSelector();
-
-            (IEnumerable<ArmourPiece> toKeep, IEnumerable<ArmourPiece> toDelete) hunterPieces = selector.ProcessArmourPieces(armourPieces, CharacterClass.Hunter);
+            var hunterSelector = new ArmourPieceSelector(armourPieces, CharacterClass.Hunter);
+            (IEnumerable<ArmourPiece> toKeep, IEnumerable<ArmourPiece> toDelete) hunterPieces = hunterSelector.ProcessArmourPieces();
             OutputResults(hunterPieces.toKeep, hunterPieces.toDelete);
-            (IEnumerable<ArmourPiece> toKeep, IEnumerable<ArmourPiece> toDelete) titanPieces = selector.ProcessArmourPieces(armourPieces, CharacterClass.Titan);
+
+            var titanSelector = new ArmourPieceSelector(armourPieces, CharacterClass.Titan);
+            (IEnumerable<ArmourPiece> toKeep, IEnumerable<ArmourPiece> toDelete) titanPieces = titanSelector.ProcessArmourPieces();
             OutputResults(titanPieces.toKeep, titanPieces.toDelete);
-            (IEnumerable<ArmourPiece> toKeep, IEnumerable<ArmourPiece> toDelete) warlockPieces = selector.ProcessArmourPieces(armourPieces, CharacterClass.Warlock);
+
+            var warlockSelector = new ArmourPieceSelector(armourPieces, CharacterClass.Warlock);
+            (IEnumerable<ArmourPiece> toKeep, IEnumerable<ArmourPiece> toDelete) warlockPieces = warlockSelector.ProcessArmourPieces();
             OutputResults(warlockPieces.toKeep, warlockPieces.toDelete);
 
             return true;


### PR DESCRIPTION
This simplifies processing at the cost of having some items ending up in the
keep list just because of their name

Also refactor ArmourPieceSelector to track class and perks as member varibles.

Change Program to create a seperate ArmourPieceSelector for each class.