### PR TITLE
Refactor synergy calculation

### DIFF
--- a/DestinyArmourSelector/ArmourPiece.cs
+++ b/DestinyArmourSelector/ArmourPiece.cs
@@ -2,12 +2,17 @@
 
 namespace DestinyArmourSelector
 {
+    using Interfaces;
     using System.Text;
 
     public class ArmourPiece
     {
-        public ArmourPiece(ArmourType armourType)
+        ISynergyCalculator _synergyCalculator;
+        string _synergy = null;
+
+        public ArmourPiece(ArmourType armourType, ISynergyCalculator synergyCalculator)
         {
+            _synergyCalculator = synergyCalculator;
             ArmourType = armourType;
         }
 
@@ -31,7 +36,18 @@ namespace DestinyArmourSelector
 
         public PerkGroup SecondaryPerks { get; set; }
 
-        public string Synergy { get; set; }
+        public string Synergy
+        {
+            get
+            {
+                if (_synergy == null)
+                {
+                    _synergy = _synergyCalculator.CalculateSynergy(PrimaryPerks, SecondaryPerks);
+                }
+
+                return _synergy;
+            }
+        }
 
         public override string ToString()
         {

--- a/DestinyArmourSelector/ArmourPieceCreator.cs
+++ b/DestinyArmourSelector/ArmourPieceCreator.cs
@@ -2,6 +2,7 @@
 
 namespace DestinyArmourSelector
 {
+    using Interfaces;
     using System.Collections.Generic;
     using System.IO;
     using System.Threading.Tasks;

--- a/DestinyArmourSelector/ArmourPieceFactory.cs
+++ b/DestinyArmourSelector/ArmourPieceFactory.cs
@@ -2,6 +2,8 @@
 
 namespace DestinyArmourSelector
 {
+    using Interfaces;
+
     public class ArmourPieceFactory : IArmourPieceFactory
     {
         private readonly ArmourType _armourType = ArmourType.Unknown;
@@ -65,7 +67,7 @@ namespace DestinyArmourSelector
                 synergy = tokens[12];
             }
 
-            return new ArmourPiece(_armourType)
+            return new ArmourPiece(_armourType, new StaticSynergyCalculator(synergy))
             {
                 BasePerks = basePerks,
                 Class = characterClass,
@@ -76,7 +78,6 @@ namespace DestinyArmourSelector
                 PrimaryPerks = primaryPerks,
                 RowNumber = rowNumber,
                 SecondaryPerks = secondaryPerks,
-                Synergy = synergy
             };
         }
     }

--- a/DestinyArmourSelector/DIMArmourPieceFactory.cs
+++ b/DestinyArmourSelector/DIMArmourPieceFactory.cs
@@ -2,26 +2,23 @@
 
 namespace DestinyArmourSelector
 {
-    using System;
+    using Interfaces;
     using System.Collections.Generic;
-    using System.Text;
 
     public class DIMArmourPieceFactory : IArmourPieceFactory
     {
         // 0                1             2                    3         4          5       6           7      8                        9                10          11      12        13    14      15     16          17            18        19        20          21     22 ...
         // Name,            Hash,         Id,                  Tag,      Tier,      Type,   Equippable, Power, Masterwork Type,         Masterwork Tier, Owner,      Locked, Equipped, Year, Season, Event, DTR Rating, # of Reviews, Mobility, Recovery, Resilience, Notes, Perks
 
-        private int _nameIndex = 0;
-        private int _typeIndex = 5;
-        private int _classIndex = 6;
-        private int _powerIndex = 7;
-        private int _elementIndex = 8;
-        private int _masterworkIndex = 9;
-        private int _perksIndex = 22;
+        private readonly int _nameIndex = 0;
+        private readonly int _typeIndex = 5;
+        private readonly int _classIndex = 6;
+        private readonly int _powerIndex = 7;
+        private readonly int _elementIndex = 8;
+        private readonly int _masterworkIndex = 9;
+        private readonly int _perksIndex = 22;
 
         private readonly ArmourType _armourType = ArmourType.Unknown;
-        private static readonly string _enhancedPrefix = "Enhanced ";
-        private static readonly string _unflinchingAimPrefix = "Unflinching ";
 
         // HashSets used for finding various types of perks
         private static HashSet<string> _basePerkStrings = new HashSet<string>
@@ -70,230 +67,6 @@ namespace DestinyArmourSelector
             "Reserves",
             "Scavenger"
         };
-
-        // HashSets used for tracking perk synergy for each weapon type
-        private static readonly HashSet<string> _autoRifleSynergy = new HashSet<string>
-        {
-            "Auto Rifle",
-            "Kinetic",
-            "Energy",
-            "Scatter",
-            "Rifle"
-        };
-
-        private static readonly HashSet<string> _scoutRifleSynergy = new HashSet<string>
-        {
-            "Scout Rifle",
-            "Kinetic",
-            "Energy",
-            "Precision",
-            "Rifle"
-        };
-
-        private static readonly HashSet<string> _pulseRifleSynergy = new HashSet<string>
-        {
-            "Scout Rifle",
-            "Kinetic",
-            "Energy",
-            "Scatter",
-            "Rifle"
-        };
-
-        private static readonly HashSet<string> _handCannonSynergy = new HashSet<string>
-        {
-            "Hand Cannon",
-            "Kinetic",
-            "Energy",
-            "Precision",
-            "Light Arms"
-        };
-
-        private static readonly HashSet<string> _subMachineGunSynergy = new HashSet<string>
-        {
-            "Submachine Gun",
-            "Kinetic",
-            "Energy",
-            "Scatter",
-            "Light Arms"
-        };
-
-        private static readonly HashSet<string> _sidearmSynergy = new HashSet<string>
-        {
-            "Sidearm",
-            "Kinetic",
-            "Energy",
-            "Scatter",
-            "Light Arms"
-        };
-
-        private static readonly HashSet<string> _bowSynergy = new HashSet<string>
-        {
-            "Bow",
-            "Kinetic",
-            "Energy",
-            "Precision",
-            "Oversize"
-        };
-
-        private static readonly HashSet<string> _shotgunSynergy = new HashSet<string>
-        {
-            "Shotgun",
-            "Kinetic",
-            "Energy",
-            "Power",
-            "Pump Action",
-            "Oversize"
-        };
-
-        private static readonly HashSet<string> _grenadeLauncherSynergy = new HashSet<string>
-        {
-            "Grenade Launcher",
-            "Kinetic",
-            "Energy",
-            "Power",
-            "Oversize",
-            "Heavy Lifting"
-        };
-
-        private static readonly HashSet<string> _fusionRifleSynergy = new HashSet<string>
-        {
-            "Fusion Rifle",
-            "Energy",
-            "Scatter",
-            "Rifle",
-            "Light Reactor",
-        };
-
-        private static readonly HashSet<string> _sniperRifleSynergy = new HashSet<string>
-        {
-            "Sniper Rifle",
-            "Kinetic",
-            "Energy",
-            "Power",
-            "Precision",
-            "Rifle",
-            "Remote Connection",
-        };
-
-        private static readonly HashSet<string> _traceRifleSynergy = new HashSet<string>
-        {
-            "Trace Rifle",
-            "Energy",
-            "Precision",
-            "Rifle"
-        };
-
-        private static readonly HashSet<string> _swordSynergy = new HashSet<string>
-        {
-            "Sword",
-            "Power",
-            "Heavy Lifting"
-        };
-
-        private static readonly HashSet<string> _rocketLauncherSynergy = new HashSet<string>
-        {
-            "Rocket Launcher",
-            "Power",
-            "Oversize",
-            "Heavy Lifting"
-        };
-
-        private static readonly HashSet<string> _linearFusionSynergy = new HashSet<string>
-        {
-            "Linear Fusion",
-            "Power",
-            "Precision",
-            "Rifle",
-            "Heavy Lifting"
-        };
-
-        private static readonly HashSet<string> _machineGunSynergy = new HashSet<string>
-        {
-            "Machine Gun",
-            "Power",
-            "Heavy Lifting"
-        };
-
-        private static readonly Dictionary<string, HashSet<string>> _weaponTypeSynergies = new Dictionary<string, HashSet<string>>
-        {
-            { "Auto Rifle", _autoRifleSynergy },
-            { "Scout Rifle", _scoutRifleSynergy },
-            { "Pulse Rifle", _pulseRifleSynergy },
-            { "Hand Cannon", _handCannonSynergy },
-            { "Submachine Gun", _subMachineGunSynergy },
-            { "Sidearm", _sidearmSynergy },
-            { "Bow", _bowSynergy },
-            { "Arrow", _bowSynergy },
-            { "Shotgun", _shotgunSynergy },
-            { "Grenade Launcher", _grenadeLauncherSynergy },
-            { "Fusion Rifle", _fusionRifleSynergy },
-            { "Sniper Rifle", _sniperRifleSynergy },
-            { "Trace Rifle", _traceRifleSynergy },
-            { "Sword", _swordSynergy },
-            { "Rocket Launcher", _rocketLauncherSynergy },
-            { "Linear Fusion", _linearFusionSynergy },
-            { "Linear Fusion Rifle", _linearFusionSynergy },
-            { "Machine Gun", _machineGunSynergy }
-        };
-
-        private static readonly HashSet<string> _primarySynergy = new HashSet<string>
-        {
-            "Auto Rifle",
-            "Scout Rifle",
-            "Pulse Rifle",
-            "Hand Cannon",
-            "Submachine Gun",
-            "Sidearm",
-            "Bow",
-            "Light Arms",
-            "Rifle",
-            "Scatter",
-            "Oversize",
-            "Kinetic",
-            "Energy",
-        };
-
-        private static readonly HashSet<string> _specialSynergy = new HashSet<string>
-        {
-            "Shotgun",
-            "Grenade Launcher",
-            "Fusion Rifle",
-            "Sniper Rifle",
-            "Trace Rifle",
-            "Kinetic",
-            "Energy",
-            "Oversize",
-            "Precision",
-            "Scatter",
-            "Rifle",
-            "Light Reactor",
-            "Pump Action",
-            "Remote Connection",
-        };
-
-        private static readonly HashSet<string> _heavySynergy = new HashSet<string>
-        {
-            "Sword",
-            "Grenade Launcher",
-            "Rocket Launcher",
-            "Linear Fusion",
-            "Machine Gun",
-            "Sniper Rifle",
-            "Shotgun",
-            "Power",
-            "Oversize",
-            "Rifle",
-            "Heavy Lifting"
-        };
-
-
-        private static readonly Dictionary<string, HashSet<string>> _ammoFinderSynergies = new Dictionary<string, HashSet<string>>
-        {
-            { "Primary", _primarySynergy },
-            { "Special", _specialSynergy },
-            { "Heavy", _heavySynergy },
-        };
-
 
         // HashSets from here down are currently unused. Kept around partly for documentation purposes and partly 
         // because I think I should be able to generate the HashSets above from these somehow...
@@ -520,9 +293,7 @@ namespace DestinyArmourSelector
                 }
             }
 
-            string synergy = CalculateSynergy(primaryPerks, secondaryPerks);
-
-            return new ArmourPiece(armourType)
+            return new ArmourPiece(armourType, new SimpleSynergyCalculator())
             {
                 BasePerks = basePerks,
                 Class = characterClass,
@@ -533,101 +304,7 @@ namespace DestinyArmourSelector
                 PrimaryPerks = primaryPerks,
                 RowNumber = rowNumber,
                 SecondaryPerks = secondaryPerks,
-                Synergy = synergy
             };
-        }
-
-        private string CalculateAmmoFinderSynergy(int secondaryPerkIndex, string secondaryPerk, int primaryPerkIndex, string primaryPerk)
-        {
-            var sb = new StringBuilder();
-
-            string weaponClass = ExtractWeaponClass(secondaryPerk);
-            sb.Append(CalculateSecondaryPerkSynergy(secondaryPerkIndex, primaryPerkIndex, primaryPerk, weaponClass, _ammoFinderSynergies));
-
-            return sb.ToString();
-        }
-
-        private string CalculateScavengerOrReservesSynergy(int secondaryPerkIndex, string secondaryPerk, int primaryPerkIndex, string primaryPerk)
-        {
-            var sb = new StringBuilder();
-
-            string weaponName = ExtractWeaponName(secondaryPerk);
-            sb.Append(CalculateSecondaryPerkSynergy(secondaryPerkIndex, primaryPerkIndex, primaryPerk, weaponName, _weaponTypeSynergies));
-
-            return sb.ToString();
-        }
-
-        private string CalculateSecondaryPerkSynergy(int secondaryPerkIndex, string secondaryPerk, int primaryPerkIndex, string primaryPerk)
-        {
-            var sb = new StringBuilder();
-
-            if (!string.IsNullOrWhiteSpace(primaryPerk))
-            {
-                if (secondaryPerk.Contains("Finder"))
-                {
-                    sb.Append(CalculateAmmoFinderSynergy(secondaryPerkIndex, secondaryPerk, primaryPerkIndex, primaryPerk));
-                }
-                else // Must be Scavanger or Reserves perk
-                {
-                    sb.Append(CalculateScavengerOrReservesSynergy(secondaryPerkIndex, secondaryPerk, primaryPerkIndex, primaryPerk));
-                }
-            }
-
-            return sb.ToString();
-        }
-
-        private string CalculateSecondaryPerkSynergy(int secondaryPerkIndex, int primaryPerkIndex, string primaryPerk, string key, Dictionary<string, HashSet<string>> dictionary)
-        {
-            var sb = new StringBuilder();
-
-            primaryPerk = MassagePrimaryPerk(primaryPerk);
-
-            HashSet<string> synergies = null;
-
-            if (dictionary.TryGetValue(key, out synergies))
-            {
-                foreach (string synergy in synergies)
-                {
-                    if (primaryPerk.StartsWith(synergy))
-                    {
-                        sb.Append($"{primaryPerkIndex}_{secondaryPerkIndex}_");
-                        break;
-                    }
-                }
-            }
-
-            return sb.ToString();
-        }
-
-        private string CalculateSynergy(PerkGroup primaryPerks, PerkGroup secondaryPerks)
-        {
-            var sb = new StringBuilder();
-
-            if (!string.IsNullOrWhiteSpace(secondaryPerks.Perk1))
-            {
-                sb.Append(CalculateSecondaryPerkSynergy(1, secondaryPerks.Perk1, 1, primaryPerks.Perk1));
-                sb.Append(CalculateSecondaryPerkSynergy(1, secondaryPerks.Perk1, 2, primaryPerks.Perk2));
-                sb.Append(CalculateSecondaryPerkSynergy(1, secondaryPerks.Perk1, 3, primaryPerks.Perk3));
-            }
-
-            if (!string.IsNullOrWhiteSpace(secondaryPerks.Perk2))
-            {
-                sb.Append(CalculateSecondaryPerkSynergy(2, secondaryPerks.Perk2, 1, primaryPerks.Perk1));
-                sb.Append(CalculateSecondaryPerkSynergy(2, secondaryPerks.Perk2, 2, primaryPerks.Perk2));
-                sb.Append(CalculateSecondaryPerkSynergy(2, secondaryPerks.Perk2, 3, primaryPerks.Perk3));
-            }
-
-            return sb.ToString().Trim('_');
-        }
-
-        private string ExtractWeaponClass(string secondaryPerk)
-        {
-            return secondaryPerk.Substring(0, secondaryPerk.IndexOf("Ammo Finder"));
-        }
-
-        private string ExtractWeaponName(string secondaryPerk)
-        {
-            return secondaryPerk.Substring(0, secondaryPerk.LastIndexOf(' '));
         }
 
         private int FindIndexOfFirstBasePerk(string[] perkTokens)
@@ -742,7 +419,7 @@ namespace DestinyArmourSelector
             {
                 return Element.None;
             }
-            
+
             element = element.Substring(0, element.IndexOf(' '));
             return ElementHelpers.FromString(element);
         }
@@ -766,20 +443,6 @@ namespace DestinyArmourSelector
         private int GetPowerLevel(string[] tokens)
         {
             return int.Parse(tokens[_powerIndex]);
-        }
-
-        private string MassagePrimaryPerk(string primaryPerk)
-        {
-            if (primaryPerk.StartsWith(_unflinchingAimPrefix))
-            {
-                primaryPerk = primaryPerk.Substring(_unflinchingAimPrefix.Length);
-            }
-            else if (primaryPerk.StartsWith(_enhancedPrefix))
-            {
-                primaryPerk = primaryPerk.Substring(_enhancedPrefix.Length);
-            }
-
-            return primaryPerk;
         }
 
         private void TrimPerkTokens(string[] perkTokens)

--- a/DestinyArmourSelector/DestinyArmourSelector.csproj
+++ b/DestinyArmourSelector/DestinyArmourSelector.csproj
@@ -53,10 +53,13 @@
     <Compile Include="ArmourPieceCreator.cs" />
     <Compile Include="CsvReader.cs" />
     <Compile Include="Element.cs" />
-    <Compile Include="IArmourPieceFactory.cs" />
+    <Compile Include="Interfaces\IArmourPieceFactory.cs" />
+    <Compile Include="Interfaces\ISynergyCalculator.cs" />
     <Compile Include="PerkGroup.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SimpleSynergyCalculator.cs" />
+    <Compile Include="StaticSynergyCalculator.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/DestinyArmourSelector/Interfaces/IArmourPieceFactory.cs
+++ b/DestinyArmourSelector/Interfaces/IArmourPieceFactory.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright Small & Fast 2018
 
-namespace DestinyArmourSelector
+namespace DestinyArmourSelector.Interfaces
 {
     public interface IArmourPieceFactory
     {

--- a/DestinyArmourSelector/Interfaces/ISynergyCalculator.cs
+++ b/DestinyArmourSelector/Interfaces/ISynergyCalculator.cs
@@ -1,0 +1,9 @@
+﻿// Copyright Small & Fast 2018
+
+namespace DestinyArmourSelector.Interfaces
+{
+    public interface ISynergyCalculator
+    {
+        string CalculateSynergy(PerkGroup primaryPerks, PerkGroup secondaryPerks);
+    }
+}

--- a/DestinyArmourSelector/Program.cs
+++ b/DestinyArmourSelector/Program.cs
@@ -2,6 +2,7 @@
 
 namespace DestinyArmourSelector
 {
+    using Interfaces;
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/DestinyArmourSelector/SimpleSynergyCalculator.cs
+++ b/DestinyArmourSelector/SimpleSynergyCalculator.cs
@@ -1,0 +1,349 @@
+﻿// Copyright Small & Fast 2018
+
+namespace DestinyArmourSelector
+{
+    using Interfaces;
+    using System.Collections.Generic;
+    using System.Text;
+
+    class SimpleSynergyCalculator : ISynergyCalculator
+    {
+        private static readonly string _enhancedPrefix = "Enhanced ";
+        private static readonly string _unflinchingAimPrefix = "Unflinching ";
+
+        // HashSets used for tracking perk synergy for each weapon type
+        private static readonly HashSet<string> _autoRifleSynergy = new HashSet<string>
+        {
+            "Auto Rifle",
+            "Kinetic",
+            "Energy",
+            "Scatter",
+            "Rifle"
+        };
+
+        private static readonly HashSet<string> _scoutRifleSynergy = new HashSet<string>
+        {
+            "Scout Rifle",
+            "Kinetic",
+            "Energy",
+            "Precision",
+            "Rifle"
+        };
+
+        private static readonly HashSet<string> _pulseRifleSynergy = new HashSet<string>
+        {
+            "Scout Rifle",
+            "Kinetic",
+            "Energy",
+            "Scatter",
+            "Rifle"
+        };
+
+        private static readonly HashSet<string> _handCannonSynergy = new HashSet<string>
+        {
+            "Hand Cannon",
+            "Kinetic",
+            "Energy",
+            "Precision",
+            "Light Arms"
+        };
+
+        private static readonly HashSet<string> _subMachineGunSynergy = new HashSet<string>
+        {
+            "Submachine Gun",
+            "Kinetic",
+            "Energy",
+            "Scatter",
+            "Light Arms"
+        };
+
+        private static readonly HashSet<string> _sidearmSynergy = new HashSet<string>
+        {
+            "Sidearm",
+            "Kinetic",
+            "Energy",
+            "Scatter",
+            "Light Arms"
+        };
+
+        private static readonly HashSet<string> _bowSynergy = new HashSet<string>
+        {
+            "Bow",
+            "Kinetic",
+            "Energy",
+            "Precision",
+            "Oversize"
+        };
+
+        private static readonly HashSet<string> _shotgunSynergy = new HashSet<string>
+        {
+            "Shotgun",
+            "Kinetic",
+            "Energy",
+            "Power",
+            "Pump Action",
+            "Oversize"
+        };
+
+        private static readonly HashSet<string> _grenadeLauncherSynergy = new HashSet<string>
+        {
+            "Grenade Launcher",
+            "Kinetic",
+            "Energy",
+            "Power",
+            "Oversize",
+            "Heavy Lifting"
+        };
+
+        private static readonly HashSet<string> _fusionRifleSynergy = new HashSet<string>
+        {
+            "Fusion Rifle",
+            "Energy",
+            "Scatter",
+            "Rifle",
+            "Light Reactor",
+        };
+
+        private static readonly HashSet<string> _sniperRifleSynergy = new HashSet<string>
+        {
+            "Sniper Rifle",
+            "Kinetic",
+            "Energy",
+            "Power",
+            "Precision",
+            "Rifle",
+            "Remote Connection",
+        };
+
+        private static readonly HashSet<string> _traceRifleSynergy = new HashSet<string>
+        {
+            "Trace Rifle",
+            "Energy",
+            "Precision",
+            "Rifle"
+        };
+
+        private static readonly HashSet<string> _swordSynergy = new HashSet<string>
+        {
+            "Sword",
+            "Power",
+            "Heavy Lifting"
+        };
+
+        private static readonly HashSet<string> _rocketLauncherSynergy = new HashSet<string>
+        {
+            "Rocket Launcher",
+            "Power",
+            "Oversize",
+            "Heavy Lifting"
+        };
+
+        private static readonly HashSet<string> _linearFusionSynergy = new HashSet<string>
+        {
+            "Linear Fusion",
+            "Power",
+            "Precision",
+            "Rifle",
+            "Heavy Lifting"
+        };
+
+        private static readonly HashSet<string> _machineGunSynergy = new HashSet<string>
+        {
+            "Machine Gun",
+            "Power",
+            "Heavy Lifting"
+        };
+
+        private static readonly Dictionary<string, HashSet<string>> _weaponTypeSynergies = new Dictionary<string, HashSet<string>>
+        {
+            { "Auto Rifle", _autoRifleSynergy },
+            { "Scout Rifle", _scoutRifleSynergy },
+            { "Pulse Rifle", _pulseRifleSynergy },
+            { "Hand Cannon", _handCannonSynergy },
+            { "Submachine Gun", _subMachineGunSynergy },
+            { "Sidearm", _sidearmSynergy },
+            { "Bow", _bowSynergy },
+            { "Arrow", _bowSynergy },
+            { "Shotgun", _shotgunSynergy },
+            { "Grenade Launcher", _grenadeLauncherSynergy },
+            { "Fusion Rifle", _fusionRifleSynergy },
+            { "Sniper Rifle", _sniperRifleSynergy },
+            { "Trace Rifle", _traceRifleSynergy },
+            { "Sword", _swordSynergy },
+            { "Rocket Launcher", _rocketLauncherSynergy },
+            { "Linear Fusion", _linearFusionSynergy },
+            { "Linear Fusion Rifle", _linearFusionSynergy },
+            { "Machine Gun", _machineGunSynergy }
+        };
+
+        private static readonly HashSet<string> _primarySynergy = new HashSet<string>
+        {
+            "Auto Rifle",
+            "Scout Rifle",
+            "Pulse Rifle",
+            "Hand Cannon",
+            "Submachine Gun",
+            "Sidearm",
+            "Bow",
+            "Light Arms",
+            "Rifle",
+            "Scatter",
+            "Oversize",
+            "Kinetic",
+            "Energy",
+        };
+
+        private static readonly HashSet<string> _specialSynergy = new HashSet<string>
+        {
+            "Shotgun",
+            "Grenade Launcher",
+            "Fusion Rifle",
+            "Sniper Rifle",
+            "Trace Rifle",
+            "Kinetic",
+            "Energy",
+            "Oversize",
+            "Precision",
+            "Scatter",
+            "Rifle",
+            "Light Reactor",
+            "Pump Action",
+            "Remote Connection",
+        };
+
+        private static readonly HashSet<string> _heavySynergy = new HashSet<string>
+        {
+            "Sword",
+            "Grenade Launcher",
+            "Rocket Launcher",
+            "Linear Fusion",
+            "Machine Gun",
+            "Sniper Rifle",
+            "Shotgun",
+            "Power",
+            "Oversize",
+            "Rifle",
+            "Heavy Lifting"
+        };
+
+
+        private static readonly Dictionary<string, HashSet<string>> _ammoFinderSynergies = new Dictionary<string, HashSet<string>>
+        {
+            { "Primary", _primarySynergy },
+            { "Special", _specialSynergy },
+            { "Heavy", _heavySynergy },
+        };
+
+        public string CalculateSynergy(PerkGroup primaryPerks, PerkGroup secondaryPerks)
+        {
+            return CalculateSynergyInternal(primaryPerks, secondaryPerks);
+        }
+
+        private string CalculateAmmoFinderSynergy(int secondaryPerkIndex, string secondaryPerk, int primaryPerkIndex, string primaryPerk)
+        {
+            var sb = new StringBuilder();
+
+            string weaponClass = ExtractWeaponClass(secondaryPerk);
+            sb.Append(CalculateSecondaryPerkSynergy(secondaryPerkIndex, primaryPerkIndex, primaryPerk, weaponClass, _ammoFinderSynergies));
+
+            return sb.ToString();
+        }
+
+        private string CalculateScavengerOrReservesSynergy(int secondaryPerkIndex, string secondaryPerk, int primaryPerkIndex, string primaryPerk)
+        {
+            var sb = new StringBuilder();
+
+            string weaponName = ExtractWeaponName(secondaryPerk);
+            sb.Append(CalculateSecondaryPerkSynergy(secondaryPerkIndex, primaryPerkIndex, primaryPerk, weaponName, _weaponTypeSynergies));
+
+            return sb.ToString();
+        }
+
+        private string CalculateSecondaryPerkSynergy(int secondaryPerkIndex, string secondaryPerk, int primaryPerkIndex, string primaryPerk)
+        {
+            var sb = new StringBuilder();
+
+            if (!string.IsNullOrWhiteSpace(primaryPerk))
+            {
+                if (secondaryPerk.Contains("Finder"))
+                {
+                    sb.Append(CalculateAmmoFinderSynergy(secondaryPerkIndex, secondaryPerk, primaryPerkIndex, primaryPerk));
+                }
+                else // Must be Scavanger or Reserves perk
+                {
+                    sb.Append(CalculateScavengerOrReservesSynergy(secondaryPerkIndex, secondaryPerk, primaryPerkIndex, primaryPerk));
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        private string CalculateSecondaryPerkSynergy(int secondaryPerkIndex, int primaryPerkIndex, string primaryPerk, string key, Dictionary<string, HashSet<string>> dictionary)
+        {
+            var sb = new StringBuilder();
+
+            primaryPerk = MassagePrimaryPerk(primaryPerk);
+
+            HashSet<string> synergies = null;
+
+            if (dictionary.TryGetValue(key, out synergies))
+            {
+                foreach (string synergy in synergies)
+                {
+                    if (primaryPerk.StartsWith(synergy))
+                    {
+                        sb.Append($"{primaryPerkIndex}_{secondaryPerkIndex}_");
+                        break;
+                    }
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        private string CalculateSynergyInternal(PerkGroup primaryPerks, PerkGroup secondaryPerks)
+        {
+            var sb = new StringBuilder();
+
+            if (!string.IsNullOrWhiteSpace(secondaryPerks.Perk1))
+            {
+                sb.Append(CalculateSecondaryPerkSynergy(1, secondaryPerks.Perk1, 1, primaryPerks.Perk1));
+                sb.Append(CalculateSecondaryPerkSynergy(1, secondaryPerks.Perk1, 2, primaryPerks.Perk2));
+                sb.Append(CalculateSecondaryPerkSynergy(1, secondaryPerks.Perk1, 3, primaryPerks.Perk3));
+            }
+
+            if (!string.IsNullOrWhiteSpace(secondaryPerks.Perk2))
+            {
+                sb.Append(CalculateSecondaryPerkSynergy(2, secondaryPerks.Perk2, 1, primaryPerks.Perk1));
+                sb.Append(CalculateSecondaryPerkSynergy(2, secondaryPerks.Perk2, 2, primaryPerks.Perk2));
+                sb.Append(CalculateSecondaryPerkSynergy(2, secondaryPerks.Perk2, 3, primaryPerks.Perk3));
+            }
+
+            return sb.ToString().Trim('_');
+        }
+
+        private string ExtractWeaponClass(string secondaryPerk)
+        {
+            return secondaryPerk.Substring(0, secondaryPerk.IndexOf("Ammo Finder"));
+        }
+
+        private string ExtractWeaponName(string secondaryPerk)
+        {
+            return secondaryPerk.Substring(0, secondaryPerk.LastIndexOf(' '));
+        }
+
+        private string MassagePrimaryPerk(string primaryPerk)
+        {
+            if (primaryPerk.StartsWith(_unflinchingAimPrefix))
+            {
+                primaryPerk = primaryPerk.Substring(_unflinchingAimPrefix.Length);
+            }
+            else if (primaryPerk.StartsWith(_enhancedPrefix))
+            {
+                primaryPerk = primaryPerk.Substring(_enhancedPrefix.Length);
+            }
+
+            return primaryPerk;
+        }
+    }
+}

--- a/DestinyArmourSelector/StaticSynergyCalculator.cs
+++ b/DestinyArmourSelector/StaticSynergyCalculator.cs
@@ -1,0 +1,21 @@
+﻿// Copyright Small & Fast 2018
+
+namespace DestinyArmourSelector
+{
+    using Interfaces;
+
+    public class StaticSynergyCalculator : ISynergyCalculator
+    {
+        private readonly string _synergy = string.Empty;
+
+        public StaticSynergyCalculator(string synergy)
+        {
+            _synergy = synergy;
+        }
+
+        public string CalculateSynergy(PerkGroup primaryPerks, PerkGroup secondaryPerks)
+        {
+            return _synergy;
+        }
+    }
+}


### PR DESCRIPTION
Move synergy calculation to 'SynergyCalculator classes, modeled using
ISynergyCalculator.

Add a SimpleSynergyCalculator class and move synergy related fields and
methods from DIMArmourPieceFactory to this new class.

Add a StaticSynergyCalculator class that simple returns a string passed
to the constructor.

Amend ArmourPiece to take an ISynergyCalculator and use that to implement
the getter for the Synergy property.

Remove the setter for the Synergy property.

Amend ArmourPieceFactory to create a StaticSynergyCalculator for each
ArmourPiece.

Amend DIMArmourPieceFactory to create a SimpleSynergyCalculator for each
ArmourPiece.

Add an Interfaces folder and namespace to hold both the new ISynergyCalculator
interface and the existing IArmourPieceFactory interface.